### PR TITLE
Allow network traffic ingress in low cost example

### DIFF
--- a/examples/low-cost/app.ts
+++ b/examples/low-cost/app.ts
@@ -13,6 +13,8 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
+  Peer,
+  Port,
   Vpc,
 } from "aws-cdk-lib/aws-ec2";
 import { FckNatInstanceProvider } from "cdk-fck-nat";
@@ -109,6 +111,7 @@ class LowCostStack extends Stack {
       natGatewayProvider,
       vpcName,
     });
+    natGatewayProvider.securityGroup.addIngressRule(Peer.ipv4(vpc.vpcCidrBlock), Port.allTraffic());
     return vpc;
   }
   #createDnsRecords(nextjs: NextjsGlobalFunctions, hostedZone: IHostedZone) {


### PR DESCRIPTION
Relates to #32

With the [low cost example](https://github.com/cdklabs/cdk-nextjs/tree/main/examples/low-cost) the `Custom::NextjsAssetsDeployment` resource consistently fails to create or delete.
Logs indicate connection issue.

Adding this ingress rule to the VPC fixed it in my set up. Disclaimer: I have not actually checked out this exact example and deployed that, but this is the same diff I made in my setup.

Seems this line is [also present in related discussion about this](https://github.com/cdklabs/cdk-nextjs/issues/16#issuecomment-2454762226).