### PR TITLE
fix:  basePath not being applied to static assets in S3 and Cloudfront behaviors

### DIFF
--- a/API.md
+++ b/API.md
@@ -2210,6 +2210,7 @@ const nextjsAssetsDeploymentProps: NextjsAssetsDeploymentProps = { ... }
 | <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.dockerImageCode">dockerImageCode</a></code> | <code>aws-cdk-lib.aws_lambda.DockerImageCode</code> | *No description.* |
 | <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.nextjsType">nextjsType</a></code> | <code><a href="#cdk-nextjs.NextjsType">NextjsType</a></code> | *No description.* |
 | <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | *No description.* |
+| <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.basePath">basePath</a></code> | <code>string</code> | Prefix to the URI path the app will be served at. |
 | <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.debug">debug</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.overrides">overrides</a></code> | <code><a href="#cdk-nextjs.NextjsAssetDeploymentOverrides">NextjsAssetDeploymentOverrides</a></code> | *No description.* |
 | <code><a href="#cdk-nextjs.NextjsAssetsDeploymentProps.property.relativePathToWorkspace">relativePathToWorkspace</a></code> | <code>string</code> | *No description.* |
@@ -2280,6 +2281,25 @@ public readonly vpc: IVpc;
 - *Type:* aws-cdk-lib.aws_ec2.IVpc
 
 ---
+
+##### `basePath`<sup>Optional</sup> <a name="basePath" id="cdk-nextjs.NextjsAssetsDeploymentProps.property.basePath"></a>
+
+```typescript
+public readonly basePath: string;
+```
+
+- *Type:* string
+
+Prefix to the URI path the app will be served at.
+
+---
+
+*Example*
+
+```typescript
+"/my-base-path"
+```
+
 
 ##### `debug`<sup>Optional</sup> <a name="debug" id="cdk-nextjs.NextjsAssetsDeploymentProps.property.debug"></a>
 

--- a/API.md
+++ b/API.md
@@ -8538,6 +8538,7 @@ const optionalNextjsAssetsDeploymentProps: OptionalNextjsAssetsDeploymentProps =
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-nextjs.OptionalNextjsAssetsDeploymentProps.property.accessPoint">accessPoint</a></code> | <code>aws-cdk-lib.aws_efs.AccessPoint</code> | *No description.* |
+| <code><a href="#cdk-nextjs.OptionalNextjsAssetsDeploymentProps.property.basePath">basePath</a></code> | <code>string</code> | Prefix to the URI path the app will be served at. |
 | <code><a href="#cdk-nextjs.OptionalNextjsAssetsDeploymentProps.property.buildImageDigest">buildImageDigest</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs.OptionalNextjsAssetsDeploymentProps.property.containerMountPathForEfs">containerMountPathForEfs</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-nextjs.OptionalNextjsAssetsDeploymentProps.property.debug">debug</a></code> | <code>boolean</code> | *No description.* |
@@ -8556,6 +8557,18 @@ public readonly accessPoint: AccessPoint;
 ```
 
 - *Type:* aws-cdk-lib.aws_efs.AccessPoint
+
+---
+
+##### `basePath`<sup>Optional</sup> <a name="basePath" id="cdk-nextjs.OptionalNextjsAssetsDeploymentProps.property.basePath"></a>
+
+```typescript
+public readonly basePath: string;
+```
+
+- *Type:* string
+
+Prefix to the URI path the app will be served at.
 
 ---
 

--- a/src/generated-structs/OptionalNextjsAssetsDeploymentProps.ts
+++ b/src/generated-structs/OptionalNextjsAssetsDeploymentProps.ts
@@ -21,6 +21,11 @@ export interface OptionalNextjsAssetsDeploymentProps {
    */
   readonly debug?: boolean;
   /**
+   * Prefix to the URI path the app will be served at.
+   * @stability stable
+   */
+  readonly basePath?: string;
+  /**
    * @stability stable
    */
   readonly vpc?: aws_ec2.IVpc;

--- a/src/nextjs-assets-deployment.ts
+++ b/src/nextjs-assets-deployment.ts
@@ -28,6 +28,11 @@ export interface NextjsAssetDeploymentOverrides {
 export interface NextjsAssetsDeploymentProps {
   readonly accessPoint: AccessPoint;
   /**
+   * Prefix to the URI path the app will be served at.
+   * @example "/my-base-path"
+   */
+  readonly basePath?: string;
+  /**
    * @see {@link NextjsBuild.buildImageDigest}
    */
   readonly buildImageDigest: string;
@@ -177,13 +182,18 @@ export class NextjsAssetsDeployment extends Construct {
     const root = "/app";
     const actions: CustomResourceProperties["actions"] = [];
     if (this.props.staticAssetsBucket?.bucketName) {
+      // Prepare the destination key prefix with basePath when available
+      const staticKeyPrefix = this.props.basePath
+        ? `${this.props.basePath.replace(/^\//, "")}/_next/static`
+        : "_next/static";
+
       actions.push(
         // static files
         {
           type: "fs-to-s3",
           sourcePath: join(root, ".next", "static"),
           destinationBucketName: this.props.staticAssetsBucket.bucketName,
-          destinationKeyPrefix: "_next/static",
+          destinationKeyPrefix: staticKeyPrefix,
         },
         // public directory to s3 for CloudFront -> S3
         {

--- a/src/nextjs-distribution.ts
+++ b/src/nextjs-distribution.ts
@@ -349,7 +349,7 @@ export class NextjsDistribution extends Construct {
   }
   private addStaticBehaviors() {
     this.distribution.addBehavior(
-      "_next/static*",
+      this.getPathPattern("_next/static*"),
       this.staticOrigin,
       this.staticBehaviorOptions,
     );

--- a/src/root-constructs/nextjs-global-containers.ts
+++ b/src/root-constructs/nextjs-global-containers.ts
@@ -140,6 +140,7 @@ export class NextjsGlobalContainers extends Construct {
   private createNextjsAssetsDeployment() {
     return new NextjsAssetsDeployment(this, "NextjsAssetsDeployment", {
       accessPoint: this.nextjsFileSystem.accessPoint,
+      basePath: this.props.basePath,
       buildImageDigest: this.nextjsBuild.buildImageDigest,
       containerMountPathForEfs: this.nextjsBuild.containerMountPathForEfs,
       dockerImageCode: this.nextjsBuild.imageForNextjsAssetsDeployment,

--- a/src/root-constructs/nextjs-global-functions.ts
+++ b/src/root-constructs/nextjs-global-functions.ts
@@ -143,6 +143,7 @@ export class NextjsGlobalFunctions extends Construct {
   private createNextjsAssetsDeployment() {
     return new NextjsAssetsDeployment(this, "NextjsAssetsDeployment", {
       accessPoint: this.nextjsFileSystem.accessPoint,
+      basePath: this.props.basePath,
       buildImageDigest: this.nextjsBuild.buildImageDigest,
       dockerImageCode: this.nextjsBuild.imageForNextjsAssetsDeployment,
       containerMountPathForEfs: this.nextjsBuild.containerMountPathForEfs,


### PR DESCRIPTION
## Description
Fix for basePath not being applied to static assets in S3
Fix for basePath not being applied to Cloudfront behavior _next/static* 

## Problem
When a basePath is configured, the basePath needs to be used as a prefix to the CloudFront _next/static*. It also needs to be used as an S3 prefix for assets uploaded to S3.

## Solution
- Added basePath property to NextjsAssetsDeploymentProps
- Modified the fs-to-s3 destination prefix to include basePath when present
- Updated the NextjsGlobalFunctions and NextjsGlobalContainers to pass basePath to NextjsAssetsDeployment

## Testing
Tested by creating a local package and verifying that static assets are correctly uploaded
to S3 under the basePath prefix.
