### PR TITLE
fix: wire up dynamicResponseHeadersPolicyProps override

### DIFF
--- a/src/nextjs-distribution.ts
+++ b/src/nextjs-distribution.ts
@@ -284,7 +284,7 @@ export class NextjsDistribution extends Construct {
           "NextJS Dynamic Response Headers Policy",
           Stack.of(this).stackName,
         ),
-        ...this.props.overrides?.dynamicBehaviorOptions?.responseHeadersPolicy,
+        ...this.props.overrides?.dynamicResponseHeadersPolicyProps,
       });
     return {
       allowedMethods: AllowedMethods.ALLOW_ALL,


### PR DESCRIPTION
## Summary
- `createDynamicBehaviorOptions` in `src/nextjs-distribution.ts` was spreading `overrides?.dynamicBehaviorOptions?.responseHeadersPolicy` when constructing the default `ResponseHeadersPolicy`, instead of `overrides?.dynamicResponseHeadersPolicyProps` — so the documented `dynamicResponseHeadersPolicyProps` override was silently ignored.
- Fixed to spread `overrides?.dynamicResponseHeadersPolicyProps`, matching the existing pattern used for `staticResponseHeadersPolicyProps` and `imageResponseHeadersPolicyProps`.

Fixes #247

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on the changed file
- [ ] Manual verification that a stack using `overrides.dynamicResponseHeadersPolicyProps` now applies those props to the generated `ResponseHeadersPolicy`